### PR TITLE
Put the rss rel link on all the pages.

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -9,10 +9,7 @@
   <title>{{ .Site.Title }}</title>
   {{ partial "opengraph.html" . }}
 
-  {{- with .OutputFormats.Get "rss" }}
-  {{ printf `
-  <link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
-  {{- end }}
+  <link rel="alternate" type="application/rss+xml" href="{{ "index.xml" | absURL }}" title="{{ site.Title }}">
   {{ $css := resources.Get "css/main.css" }}
   <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 </head>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -9,7 +9,9 @@
   <title>{{ .Site.Title }}</title>
   {{ partial "opengraph.html" . }}
 
-  <link rel="alternate" type="application/rss+xml" href="{{ "index.xml" | absURL }}" title="{{ site.Title }}">
+  {{- with site.Home.OutputFormats.Get "rss" }}
+  <link rel="alternate" type="{{ .MediaType.Type }}" href="{{ .Permalink }}" title="{{ site.Title }}">
+  {{- end }}
   {{ $css := resources.Get "css/main.css" }}
   <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 </head>


### PR DESCRIPTION
I tried to get updates by passing the https://gem.coop/updates/ url to my feed reader and it failed to find the rss feed. This adds the header to all the places and points to the main index.xml feed.

I didn't think that having a unique feed for each page would be super useful, but that's another way to go about this!